### PR TITLE
[fix] Use `process.env.USERPROFILE` if $HOME isn't set

### DIFF
--- a/lib/complete.js
+++ b/lib/complete.js
@@ -6,7 +6,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var dir = path.join(process.env.HOME, '.node-completion');
+var dir = path.join(process.env.HOME || process.env.USERPROFILE, '.node-completion');
 var hop = Object.prototype.hasOwnProperty;
 var bashrc = getRc();
 var argv = require('optimist').argv;


### PR DESCRIPTION
Due to changes in node v0.10, `path.join` no longer accepts `undefined`
as a correct parameter which causes this module to fail on Windows,
which sets $USERPROFILE instead of $HOME.

Disclaimer: I have no actual idea if this'll make the module work on
Windows. It might if people have a full bash shell set up.
