### PR TITLE
Fixes #18 - Throw on complete failure instead of exiting the process

### DIFF
--- a/lib/complete.js
+++ b/lib/complete.js
@@ -128,7 +128,7 @@ function ensure(program) {
 
 ensure.rc = function() {
 
-  var data = '', err;
+  var data = '', err, msg = complete.installMessage;
 
   if (argv.install) {
     process.stdout.write(source);
@@ -145,21 +145,19 @@ ensure.rc = function() {
   if ((err && err.code === 'ENOENT') || !~data.indexOf('# NODE-COMPLETE')) {
     data += source;
 
-    if (!complete.installMessage) {
+    if (!msg) {
       var name = getName();
-      process.stdout.write([
+      msg = [
         '',
         'ATTENTION: Your environment doesn\'t support auto-complete.',
         'To enable it, try running the following commands:',
         '  node ' + name + ' --install >> ' + bashrc,
         '  source ' + process.env['HOME'] + '/.node-completion/' + name,
         ''
-      ].join('\r\n'));
+      ].join('\r\n');
     }
-    else {
-      process.stdout.write(complete.installMessage);
-    }
-    process.exit(0);
+
+    throw msg;
   }
   
 


### PR DESCRIPTION
Using `throw` instead of `process.exit` so the user can wrap the failure and control the process themselves.
