### PR TITLE
Less strict auto complete string check

### DIFF
--- a/lib/complete.js
+++ b/lib/complete.js
@@ -1,7 +1,7 @@
-// 
+//
 // complete
 // Bash Completion for node.js
-// 
+//
 
 var fs = require('fs');
 var path = require('path');
@@ -15,9 +15,9 @@ var commands;
 var program;
 var opt;
 var words = [];
-// 
+//
 // Completion
-// 
+//
 function complete(options) {
 
   options = options || {};
@@ -113,7 +113,7 @@ function completeWords() {
   }
 }
 
-// 
+//
 // Ensure Completion Script and Startup Code
 //
 function ensure(program) {
@@ -121,7 +121,7 @@ function ensure(program) {
   // These don't need to be done in serial,
   // so we can make this function more
   // efficient by going async.
-  
+
   ensure.script(program);
   ensure.rc();
 }
@@ -134,7 +134,7 @@ ensure.rc = function() {
     process.stdout.write(source);
     process.exit(0);
   }
-  
+
   try {
     data = String(fs.readFileSync(bashrc));
   }
@@ -142,7 +142,7 @@ ensure.rc = function() {
     err = ex;
   }
 
-  if ((err && err.code === 'ENOENT') || !~data.indexOf('# NODE-COMPLETE')) {
+  if ((err && err.code === 'ENOENT') || !~data.match(/\#\snode[-\s]complet/gi)) {
     data += source;
 
     if (!msg) {
@@ -159,7 +159,7 @@ ensure.rc = function() {
 
     throw msg;
   }
-  
+
 
 };
 
@@ -182,7 +182,7 @@ ensure.script = function(program) {
   });
 };
 
-// 
+//
 // Get RC Filename
 //
 function getRc() {
@@ -209,7 +209,7 @@ function getRc() {
   return path.join(process.env.HOME, '.bash_profile');
 }
 
-// 
+//
 // Get Script Name
 //
 function getName() {
@@ -235,7 +235,7 @@ function getName() {
   return path.basename(file);
 }
 
-// 
+//
 // Bash
 //
 var source = [
@@ -264,7 +264,7 @@ var completion = [
   ''
 ].join('\n');
 
-// 
+//
 // Helpers
 //
 function match(key, list) {
@@ -304,19 +304,19 @@ function output(key, list) {
   return echo(match(key, list));
 }
 
-// 
+//
 // Callback Style
 // Expose a lower level
 // method of doing things.
-// 
+//
 
-// 
+//
 // list
 // An array of possible matches.
-// 
+//
 complete.list = [];
 
-// 
+//
 // init
 // Initalize the autocomplete module.
 //
@@ -340,7 +340,7 @@ complete.init = function() {
   return this;
 };
 
-// 
+//
 // add
 // Echo an array or string.
 //
@@ -353,10 +353,10 @@ complete.add = function(opt) {
   echo(opt + '');
 };
 
-// 
+//
 // callback
 // The user's callback
-// 
+//
 complete.callback = function(last, args, list) {
   ;
 };
@@ -366,7 +366,7 @@ complete.callback = function(last, args, list) {
 //
 complete.installMessage = null;
 
-// 
+//
 // compgen
 // compgen is somewhat of the program entry point when actively used by
 // a completion listener. it will accept a list of arguments and return
@@ -393,7 +393,7 @@ function compgen(argl, i, callback) {
   }
 }
 
-// 
+//
 // Expose
 //
 exports = process.platform === 'win32'

--- a/lib/complete.js
+++ b/lib/complete.js
@@ -142,7 +142,7 @@ ensure.rc = function() {
     err = ex;
   }
 
-  if ((err && err.code === 'ENOENT') || !~data.match(/\#\snode[-\s]complet/i)) {
+  if ((err && err.code === 'ENOENT') || !~data.match(/#\snode[-\s]complet/i)) {
     data += source;
 
     if (!msg) {

--- a/lib/complete.js
+++ b/lib/complete.js
@@ -142,7 +142,7 @@ ensure.rc = function() {
     err = ex;
   }
 
-  if ((err && err.code === 'ENOENT') || !~data.match(/\#\snode[-\s]complet/gi)) {
+  if ((err && err.code === 'ENOENT') || !~data.match(/\#\snode[-\s]complet/i)) {
     data += source;
 
     if (!msg) {


### PR DESCRIPTION
The less strict test for `# Node Completion` will run against variations of the auto completion script. For instance, my personal .bashrc has, failing the check for `# NODE-COMPLETE`

```
# {{{
# Node Completion - Auto-generated, do not touch.
shopt -s progcomp
for f in $(command ls ~/.node-completion); do
  f="$HOME/.node-completion/$f"
  test -f "$f" && . "$f"
done
# }}}
```
