### PR TITLE
minor fix to match function to handle array

### DIFF
--- a/lib/complete.js
+++ b/lib/complete.js
@@ -275,7 +275,7 @@ function match(key, list) {
     list = [list];
   } else if (type === 'object' && !Array.isArray(list)) {
     list = Object.keys(list);
-  } else {
+  } else if (type !== 'object') {
     return '';
   }
 


### PR DESCRIPTION
Without this patch,  `match('a', ['abc', 'ab', 'bb'])` returns `''` (empty string). After applying the patch, the method returns `'abc ab'`.
